### PR TITLE
Standardize CI with Node 26

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,43 +1,107 @@
-name: Build
+name: CI
 
 on:
   push:
-    branches:
-      - "**"
+    branches: [main]
   pull_request:
-    branches:
-      - "**"
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CI: true
+
+permissions:
+  contents: read
 
 jobs:
-  testing:
+  quality:
+    name: Quality (lint/format/docs)
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v6
-      - name: Install dependencies
-        run: npm install
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '26'
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint:check
+
+      - name: Format check
+        run: npm run format:check
+
+      - name: Docs
+        run: npm run docs
+
+  test-build:
+    name: Test + Build (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    needs: [quality]
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['20', '22', '24', '26']
+
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
       - name: Build
         run: npm run build
-      - name: Run tests
-        run: npm run test
-      - name: Run lint
-        run: npm run lint
-      - name: Run format
-        run: npm run format
-      - name: Run docs
-        run: npm run docs
+
       - name: Run against junit
         run: npm run e2e:junit
+
+      - name: Run against junit nested
+        run: npm run e2e:junit-nested
+
       - name: Run against minitest
         run: npm run e2e:minitest
+
       - name: Run against surefire
         run: npm run e2e:surefire
+
+      - name: Run against surefire flaky
+        run: npm run e2e:surefire-flaky
+
+      - name: Run against surefire retry
+        run: npm run e2e:surefire-retry
+
+      - name: Run against junit problem string
+        run: npm run e2e:junit-problem-string
+
       - name: Run against glob
         run: npm run e2e:glob
+
       - name: Publish Test Results
         uses: ctrf-io/github-test-reporter@v1
         with:
-          report-path: "./ctrf/*.json"
+          report-path: './ctrf/*.json'
           github-report: true
           failed-report: true
           flaky-report: true
@@ -47,6 +111,29 @@ jobs:
           slowest-report: true
           previous-results-report: true
           upload-artifact: true
+          artifact-name: ctrf-test-report-node-${{ matrix.node }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: always()
+        if: always() && hashFiles('ctrf/*.json') != ''
+
+  security:
+    name: Security (deps audit)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '26'
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: npm audit (prod)
+        run: npm audit --omit=dev
+        continue-on-error: true


### PR DESCRIPTION
## Summary
- wrap the converter workflow in standard quality, test/build, and security jobs
- add Node 26 to the test/build matrix and run quality/security on Node 26
- retain docs generation and converter-specific e2e fixture checks
- keep CTRF test result reporting
